### PR TITLE
Update link for 'Add Staff' action in recent-actions component

### DIFF
--- a/app/inventory/components/recent-actions.tsx
+++ b/app/inventory/components/recent-actions.tsx
@@ -58,7 +58,7 @@ const RecentActions: FC<Partial<DashboardProps>> = ({ before, after }) => {
       link: "#actions/buyer/create",
     },
     { front: "New Product", icon: Boxes, link: "#actions/product/add-new" },
-    { front: "Add Staff", icon: Users, link: "#actions/staff/add-new-staff" },
+    { front: "Add Staff", icon: Users, link: "#actions/staff/create" },
   ];
   const fetchSummary = async (before?: string, after?: string) => {
     try {


### PR DESCRIPTION
This pull request fixes an issue where the link for the 'Add Staff' action in the recent-actions component was incorrect. The link has been updated to "#actions/staff/create".